### PR TITLE
fix overlay deadnix patterns

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,9 @@
       };
     }) // {
       overlay = final: prev: {
-        deadnix = self.packages.${prev.system};
+        inherit (self.packages.${prev.system})
+          deadnix
+        ;
       };
     };
 }


### PR DESCRIPTION
fixes:
  deadnix = nixpkgs.deadnix.deadnix;  ->  inherit (nixpkgs ) deadnix; 

 