### PR TITLE
edit: only write to files that have changed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -146,8 +146,10 @@ fn main() {
             };
         }
         if edit {
-            let new_ast = crate::edit::edit_dead_code(&content, results.into_iter());
-            fs::write(file, new_ast).expect("fs::write");
+            let (new_ast, has_changes) = crate::edit::edit_dead_code(&content, results.into_iter());
+            if has_changes {
+                fs::write(file, new_ast).expect("fs::write");
+            }
         }
     }
 


### PR DESCRIPTION
This speeds up the tool on large code bases, and avoids breaking tools
that track mtimes such as make and treefmt.
