### PR TITLE
README fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,8 @@ See [deadnix-action](https://github.com/astro/deadnix-action)
 
 ### Help
 
-```
+```console
 $ nix run github:astro/deadnix -- --help
-```
-
-```
 USAGE:
     deadnix [OPTIONS] [FILE_PATHS]...
 
@@ -59,11 +56,8 @@ Reports contain ANSI color escape codes unless the
 
 ### Scan for unused code
 
-```
+```console
 $ nix run github:astro/deadnix test.nix
-```
-
-```
 Warning: Unused declarations were found.
     ╭─[example.nix:1:1]
     │
@@ -97,7 +91,7 @@ Warning: Unused declarations were found.
 
 **Do commit** your changes into version control **before!**
 
-```
+```console
 $ nix run github:astro/deadnix -- -eq test.nix
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,42 +13,34 @@ See [deadnix-action](https://github.com/astro/deadnix-action)
 
 ```console
 $ nix run github:astro/deadnix -- --help
-USAGE:
-    deadnix [OPTIONS] [FILE_PATHS]...
+Find dead code in .nix files
 
-ARGS:
-    <FILE_PATHS>...    .nix files, or directories with .nix files inside [default: .]
+Usage: deadnix [OPTIONS] [FILE_PATHS]...
 
-OPTIONS:
-    -_, --no-underscore
-            Don't check any bindings that start with a _
+Arguments:
+  [FILE_PATHS]...  .nix files, or directories with .nix files inside [default: .]
 
-    -e, --edit
-            Remove unused code and write to source file
-
-    -f, --fail
-            Exit with 1 if unused code has been found
-
-    -h, --hidden
-            Recurse into hidden subdirectories and process hidden .*.nix files
-
-        --help
-            Print help information
-
-    -l, --no-lambda-arg
-            Don't check lambda parameter arguments
-
-    -L, --no-lambda-pattern-names
-            Don't check lambda attrset pattern names (don't break nixpkgs callPackage)
-
-    -o, --output-format <OUTPUT_FORMAT>
-            Output format to use [default: human-readable] [possible values: human-readable, json]
-
-    -q, --quiet
-            Don't print dead code report
-
-    -V, --version
-            Print version information
+Options:
+  -l, --no-lambda-arg
+          Don't check lambda parameter arguments
+  -L, --no-lambda-pattern-names
+          Don't check lambda attrset pattern names (don't break nixpkgs callPackage)
+  -_, --no-underscore
+          Don't check any bindings that start with a _
+  -q, --quiet
+          Don't print dead code report
+  -e, --edit
+          Remove unused code and write to source file
+  -h, --hidden
+          Recurse into hidden subdirectories and process hidden .*.nix files
+      --help
+          
+  -f, --fail
+          Exit with 1 if unused code has been found
+  -o, --output-format <OUTPUT_FORMAT>
+          Output format to use [default: human-readable] [possible values: human-readable, json]
+  -V, --version
+          Print version information
 ```
 
 Reports contain ANSI color escape codes unless the

--- a/README.md
+++ b/README.md
@@ -49,33 +49,23 @@ Reports contain ANSI color escape codes unless the
 ### Scan for unused code
 
 ```console
-$ nix run github:astro/deadnix test.nix
+$ nix run github:astro/deadnix example.nix                                               
 Warning: Unused declarations were found.
     ╭─[example.nix:1:1]
-    │
-  1 │ unusedArgs@{ unusedArg, usedArg, ... }:
-    · ─────┬────   ────┬────
-    ·      │           ╰────── Unused lambda pattern: unusedArg
-    ·      │
-    ·      ╰────────────────── Unused lambda pattern: unusedArgs
-  3 │   inherit (builtins) unused_inherit;
-    ·                      ───────┬──────
-    ·                             ╰──────── Unused let binding: unused_inherit
-  5 │   unused = "fnord";
-    ·   ───┬──
-    ·      ╰──── Unused let binding: unused
- 10 │   shadowed = 42;
-    ·   ────┬───
-    ·       ╰───── Unused let binding: shadowed
- 11 │   _unused = unused: false;
-    ·   ───┬───   ───┬──
-    ·      │         ╰──── Unused lambda argument: unused
-    ·      │
-    ·      ╰────────────── Unused let binding: _unused
- 13 │   x = { unusedArg2, x ? args.y, ... }@args: used1 + x;
-    ·         ─────┬────
-    ·              ╰────── Unused lambda pattern: unusedArg2
-────╯
+  1 │unusedArgs@{ unusedArg, usedArg, ... }:
+    ·     │           ╰───── Unused lambda pattern: unusedArg
+    ·     ╰───────────────── Unused lambda pattern: unusedArgs
+  3 │  inherit (builtins) unused_inherit;
+    ·                            ╰─────── Unused let binding: unused_inherit
+  5 │  unused = "fnord";
+    ·     ╰─── Unused let binding: unused
+ 10 │  shadowed = 42;
+    ·      ╰──── Unused let binding: shadowed
+ 11 │  _unused = unused: false;
+    ·     │         ╰─── Unused lambda argument: unused
+    ·     ╰───────────── Unused let binding: _unused
+ 13 │  x = { unusedArg2, x ? args.y, ... }@args: used1 + x;
+    ·             ╰───── Unused lambda pattern: unusedArg2
 ```
 
 


### PR DESCRIPTION
* Use `console` syntax highlighting
* Update the help text to match the current output

To preview the rendered Markdown for the Microsoft GitHub Git forge, view the merge request’s `README`: https://github.com/toastal/deadnix/blob/read/README.md 