### PR TITLE
Add `libiconv` (needed  by macOS devshell) to `flake.nix`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
           };
 
           devShells.default = with pkgs; mkShell {
-            nativeBuildInputs = [ cargo rustc rustfmt rustPackages.clippy rust-analyzer ];
+            nativeBuildInputs = [ cargo rustc rustfmt rustPackages.clippy rust-analyzer libiconv ];
             RUST_SRC_PATH = rustPlatform.rustLibSrc;
           };
         })


### PR DESCRIPTION
Otherwise it fails with:
```
error: linking with `cc` failed: exit status: 1
  | ...

= note: ld: library not found for -liconv
          clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
```