### PR TITLE
Fix warning on nix lazy-trees branch

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
         pkgs.rustPlatform.buildRustPackage {
           pname = "deadnix";
           version = self.sourceInfo.lastModifiedDate;
-          src = ./.;
+          src = self;
           cargoLock.lockFile = ./Cargo.lock;
           nativeCheckInputs = [ pkgs.clippy ];
           doCheck = true;


### PR DESCRIPTION
`warning: Performing inefficient double copy of path 'X' to the store. This can typically be avoided by rewriting an attribute like `src = ./.` to `src = builtins.path { path = ./.; name = "source"; }`.`