### PR TITLE
Fix build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,12 +34,16 @@
       (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-        in
-        {
+
           packages = {
             default = self.packages."${system}".deadnix;
             deadnix = deadnixLambda pkgs;
           };
+        in
+        {
+          inherit packages;
+
+          checks = packages;
 
           apps.default = utils.lib.mkApp {
             drv = self.packages."${system}".default;

--- a/src/dead_code.rs
+++ b/src/dead_code.rs
@@ -31,6 +31,7 @@ impl fmt::Display for DeadCode {
 
 /// Analysis settings
 #[derive(Debug, Clone)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct Settings {
     /// Ignore `...: ...`
     pub no_lambda_arg: bool,

--- a/src/dead_code_tests.rs
+++ b/src/dead_code_tests.rs
@@ -3,7 +3,7 @@
 use rowan::ast::AstNode;
 use crate::dead_code::{DeadCode, Settings};
 
-fn run_settings(content: &str, settings: Settings) -> Vec<DeadCode> {
+fn run_settings(content: &str, settings: &Settings) -> Vec<DeadCode> {
     let ast = rnix::Root::parse(content);
     assert_eq!(0, ast.errors().len());
 
@@ -11,7 +11,7 @@ fn run_settings(content: &str, settings: Settings) -> Vec<DeadCode> {
 }
 
 fn run(content: &str) -> Vec<DeadCode> {
-    run_settings(content, Settings {
+    run_settings(content, &Settings {
         no_lambda_arg: false,
         no_lambda_pattern_names: false,
         no_underscore: false,
@@ -492,7 +492,7 @@ fn used_underscore_let() {
     let results = run_settings("
       let _x = 23;
       in _x
-    ", Settings {
+    ", &Settings {
         no_lambda_arg: false,
         no_lambda_pattern_names: false,
         no_underscore: false,


### PR DESCRIPTION
Looks like a8c3e265c52dffe50e63e7f4b5068f27cc78f8b5 introduced some new clippy warnings which breaks the build. I tried to fix it with the minimal set of changes (esp given that one of the warnings is in the `pedantic` section I didn't think it was worth trying to refactor everything for it).

Maybe it would be better to run clippy as a separate flake check derivation instead of as a post-build step, but that can probably go in a separate change.