### PR TITLE
fix: use `language: rust` in `.pre-commit-hooks.yaml`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,4 +4,4 @@
   entry: deadnix
   args: [--fail]
   types: [nix]
-  language: system
+  language: rust


### PR DESCRIPTION
The current implementation uses `language: system`, which requires user to install `deadnix` locally for the pre-commit to work as intended. This is ok for local pre-commit runs, but does not generalise to CI runs, where `deadnix` may not be installed.

Setting `language: rust` ensures that `deadnix` will be installed automatically with cargo when running the pre-commit hook.

If retaining the prior behaviour is required, I propose adding another entry with `id: deadnix-system` to support it. This appears to be the practice of other hooks I have observed. Alternatively, it can be recommended that the user specify `language: system` if the wishes to use the locally installed `deadnix`.