### PR TITLE
Don't use discontinued actions-rs/* actions to resolve deprecation warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,15 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release
+      - name: Set up Rust toolchain
+        run: |
+          rustup update stable
+          rustup default stable
+      - name: Build
+        run: |
+          cargo build --release
       - uses: actions/upload-artifact@v4
         with:
           name: deadnix

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,41 +8,37 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - name: Set up Rust toolchain
+        run: |
+          rustup update stable
+          rustup default stable
+      - name: Check
+        run: |
+          cargo check
 
   test:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - name: Set up Rust toolchain
+        run: |
+          rustup update stable
+          rustup default stable
+      - name: Test
+        run: |
+          cargo test
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings -A clippy::nonminimal_bool
+      - name: Set up Rust toolchain
+        run: |
+          rustup update stable
+          rustup default stable
+          rustup component add clippy
+      - name: Run Clippy
+        run: |
+          cargo clippy -- -D warnings -A clippy::nonminimal_bool


### PR DESCRIPTION
Now using rustup (pre-isntalled on action runners) / cargo commands instead.

The actions-rs/* actions got archived in 2023, see:
* https://github.com/actions-rs/toolchain
* https://github.com/actions-rs/cargo

This resolves the many deprecation warnings that can be seen [here](https://github.com/astro/deadnix/actions/runs/13346935779):

```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

note: clippy currently find some stuff which is unrelated to this PR and also happens on main https://github.com/astro/deadnix/actions/runs/13093125888/job/36532110574